### PR TITLE
Fix compilation warnings

### DIFF
--- a/examples/example_2d.h
+++ b/examples/example_2d.h
@@ -21,7 +21,7 @@ int example_2d()
 	{
 		double x = nd(mt);
 		if (x < -4.0 || x >= 4.0) continue;
-		++y1[std::floor(x / 0.25) + 16];
+		++y1[static_cast<size_t>(std::floor(x / 0.25) + 16)];
 	}
 	for (int i = 0; i < 32; ++i)
 	{

--- a/examples/example_for_loop.h
+++ b/examples/example_for_loop.h
@@ -14,4 +14,5 @@ int example_for_loop()
 		buf = buf.PlotPoints(eq, plot::title = eq, plot::style = Style::lines);
 	}
 	buf.Flush();
+	return 0;
 }


### PR DESCRIPTION
以下のコンパイル時警告を修正
- doubleからsize_tへの暗黙的な変換
- 戻り値がない