### PR TITLE
More improvement to CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,8 +2,8 @@ include_directories(../)
 
 add_executable(examples main.cpp)
 
-target_compile_options(examples PUBLIC
+target_compile_options(examples PRIVATE
   $<$<CONFIG:Release>:-O2 -W3>
   $<$<CONFIG:Debug>:-W3>
 )
-target_compile_features(examples PUBLIC cxx_std_17)
+target_compile_features(examples PRIVATE cxx_std_17)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(../)
 
-add_executable(examples main.cpp example_2d.h example_colormap.h example_filledcurve.h example_string.h example_for_loop.h)
+add_executable(examples main.cpp)
 
 target_compile_options(examples PUBLIC
   $<$<CONFIG:Release>:-O2 -W3>


### PR DESCRIPTION
- Remove header files from add_executable() arguments, because they can be found automatically
- Use PRIVATE keyword in target_compile_options() and target_compile_features()
