### PR TITLE
Define datablocks instead of creating temporary files when drawing

### DIFF
--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -92,7 +92,8 @@ public:
 	void Command(const std::string& str);
 	void ShowCommands(bool b);
 
-	// Enable or disable datablock feature of gnuplot
+	// Enable or disable datablock feature of Gnuplot
+	// If disabled, temporary files are created to pass data to Gnuplot.
 	void EnableInMemoryDataTransfer(bool b);
 	bool IsInMemoryDataTransferEnabled();
 
@@ -104,7 +105,7 @@ protected:
 	std::string mOutput;
 	FILE* mPipe;
 	bool mShowCommands;
-	bool mInMemoryDataTransfer; // Use datablock feature of gnuplot if true (default: false)
+	bool mInMemoryDataTransfer; // Use datablock feature of Gnuplot if true (default: false)
 	template <class = void>
 	struct Paths
 	{

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -496,7 +496,8 @@ inline void MakeDataBlock(GPMCanvas* g, const Matrix<double>& map, GetX getx, Ge
 template <class ...Args>
 inline void MakeDataObject(GPMCanvas* g, Args ...args)
 {
-	if (g->IsInMemoryDataTransferEnabled()) {
+	if (g->IsInMemoryDataTransferEnabled()) 
+	{
 		MakeDataBlock(g, args...);
 	}
 	else {
@@ -705,7 +706,7 @@ std::string FilledCurveplotCommand(const FilledCurveParam& f)
 template <class GraphParam>
 std::string ColormapPlotCommand(const GraphParam& p)
 {
-    return std::string();
+	return std::string();
 }
 
 #define DEF_GPMAXIS(AXIS, axis)\
@@ -1299,7 +1300,8 @@ inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p,
 		c.pop_back();
 		break;
 	case GraphParam::DATA:
-		if (IsInMemoryDataTransferEnabled) {
+		if (IsInMemoryDataTransferEnabled) 
+		{
 			//variable name
 			c += " " + p.mGraph;
 		}
@@ -1896,7 +1898,8 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 			mCanvas->Command("set pm3d implicit");
 			mCanvas->Command("set contour base");
 			mCanvas->Command("unset surface");
-			if (mCanvas->IsInMemoryDataTransferEnabled()) {
+			if (mCanvas->IsInMemoryDataTransferEnabled()) 
+			{
 				mCanvas->Command("set table " + i.mGraph + "_cntr");
 			}
 			else {
@@ -2152,7 +2155,8 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p,
 {
 	//filename or equation
 	std::string c;
-	switch (p.mType) {
+	switch (p.mType) 
+	{
 	case GraphParam::EQUATION:
 		//equation
 		c += " " + p.mGraph;
@@ -2168,7 +2172,8 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p,
 		c.pop_back();
 		break;
 	case GraphParam::DATA:
-		if (IsInMemoryDataTransferEnabled) {
+		if (IsInMemoryDataTransferEnabled) 
+		{
 			//variable name
 			c += " " + p.mGraph;
 		}
@@ -2221,7 +2226,8 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p,
 		auto& m = p.GetColormapParam();
 		if (m.mWithContour)
 		{
-			if (IsInMemoryDataTransferEnabled) {
+			if (IsInMemoryDataTransferEnabled) 
+			{
 				c += ", " + p.mGraph + "_cntr with line";
 			}
 			else {

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -92,6 +92,10 @@ public:
 	void Command(const std::string& str);
 	void ShowCommands(bool b);
 
+	// Enable or disable datablock feature of gnuplot
+	void EnableInMemoryDataTransfer(bool b);
+	bool IsInMemoryDataTransferEnabled();
+
 	static void SetGnuplotPath(const std::string& path);
 	static std::string GetGnuplotPath();
 
@@ -100,6 +104,7 @@ protected:
 	std::string mOutput;
 	FILE* mPipe;
 	bool mShowCommands;
+	bool mInMemoryDataTransfer; // Use datablock feature of gnuplot if true (default: false)
 	template <class = void>
 	struct Paths
 	{
@@ -111,7 +116,7 @@ protected:
 
 
 inline GPMCanvas::GPMCanvas(const std::string& output, double sizex, double sizey)
-	: mOutput(output), mPipe(nullptr), mShowCommands(false)
+	: mOutput(output), mPipe(nullptr), mShowCommands(false), mInMemoryDataTransfer(false)
 {
 	if (Paths<>::msGlobalPipe != nullptr) mPipe = Paths<>::msGlobalPipe;
 	else
@@ -136,7 +141,7 @@ inline GPMCanvas::GPMCanvas(const std::string& output, double sizex, double size
 	}
 }
 inline GPMCanvas::GPMCanvas()
-	: mOutput("ADAPT_GPM2_TMPFILE"), mPipe(nullptr), mShowCommands(false)
+	: mOutput("ADAPT_GPM2_TMPFILE"), mPipe(nullptr), mShowCommands(false), mInMemoryDataTransfer(false)
 {
 	if (Paths<>::msGlobalPipe != nullptr) mPipe = Paths<>::msGlobalPipe;
 	else
@@ -322,6 +327,15 @@ inline void GPMCanvas::ShowCommands(bool b)
 	mShowCommands = b;
 }
 
+inline void GPMCanvas::EnableInMemoryDataTransfer(bool b)
+{
+	mInMemoryDataTransfer = b;
+}
+
+inline bool GPMCanvas::IsInMemoryDataTransferEnabled()
+{
+	return mInMemoryDataTransfer;
+}
 
 inline void GPMCanvas::SetGnuplotPath(const std::string& path)
 {
@@ -378,7 +392,55 @@ namespace detail
 
 using DataIterator = Variant<std::vector<double>::const_iterator, std::vector<std::string>::const_iterator>;
 
-inline void DefineDataBlock(std::vector<DataIterator>& its, size_t size, const std::string& variable_name, GPMCanvas* g)
+inline void MakeFile(std::vector<DataIterator>& its, size_t size, const std::string& filename)
+{
+	auto f = Overload([](std::vector<double>::const_iterator& it, std::ofstream& ofs) { ofs << " " << *it; ++it; },
+		[](std::vector<std::string>::const_iterator& it, std::ofstream& ofs) { ofs << " " << *it; ++it; });
+	std::ofstream ofs(filename);
+	if (!ofs) throw InvalidArg("file \"" + filename + "\" cannot open.");
+	for (size_t i = 0; i < size; ++i)
+	{
+		for (auto& it : its)
+		{
+			it.Visit(f, ofs);
+		}
+		ofs << "\n";
+	}
+}
+template <class GetX, class GetY>
+inline void MakeFile(const Matrix<double>& map, GetX getx, GetY gety, const std::string& filename)
+{
+	std::ofstream ofs(filename);
+	if (!ofs) throw InvalidArg("file \"" + filename + "\" cannot open.");
+	uint32_t xsize = map.GetSize(0);
+	uint32_t ysize = map.GetSize(1);
+	//xsize、ysizeはxcoord.size()-1、ycoord.size()-1にそれぞれ等しいはず。
+	for (uint32_t iy = 0; iy < ysize; ++iy)
+	{
+		double y = gety(iy);
+		double cy = gety.center(iy);
+		for (uint32_t ix = 0; ix < xsize; ++ix)
+		{
+			double x = getx(ix);
+			double cx = getx.center(ix);
+			ofs << x << " " << y << " " << cx << " " << cy << " " << map[ix][iy] << "\n";
+		}
+		double x = getx(xsize);
+		double cx = getx.center(xsize);
+		ofs << x << " " << y << " " << cx << " " << cy << " " << " 0\n\n";
+	}
+	double y = gety(ysize);
+	double cy = gety.center(ysize);
+	for (uint32_t ix = 0; ix < xsize; ++ix)
+	{
+		double x = getx(ix);
+		double cx = getx.center(ix);
+		ofs << x << " " << y << " " << cx << " " << cy << " " << " 0\n";
+	}
+	ofs << getx(xsize) << " " << y << " " << getx.center(xsize) << " " << cy << " 0\n";
+}
+
+inline void MakeDataBlock(GPMCanvas* g, std::vector<DataIterator>& its, size_t size, const std::string& variable_name)
 {
 	auto f = Overload([](std::vector<double>::const_iterator& it, std::ostringstream& oss) { oss << " " << *it; ++it; },
 		[](std::vector<std::string>::const_iterator& it, std::ostringstream& oss) { oss << " " << *it; ++it; });
@@ -396,7 +458,7 @@ inline void DefineDataBlock(std::vector<DataIterator>& its, size_t size, const s
 }
 
 template <class GetX, class GetY>
-inline void DefineDataBlock(const Matrix<double>& map, GetX getx, GetY gety, const std::string& variable_name, GPMCanvas* g)
+inline void MakeDataBlock(GPMCanvas* g, const Matrix<double>& map, GetX getx, GetY gety, const std::string& variable_name)
 {
 	g->Command(variable_name + " << EOD");
 	uint32_t xsize = map.GetSize(0);
@@ -429,6 +491,30 @@ inline void DefineDataBlock(const Matrix<double>& map, GetX getx, GetY gety, con
 	}
 	g->Command(std::to_string(getx(xsize)) + " " + std::to_string(y) + " " + std::to_string(getx.center(xsize))
 		+ " " + std::to_string(cy) + " 0\nEOD");
+}
+
+template <class ...Args>
+inline void MakeDataObject(GPMCanvas* g, Args ...args)
+{
+	if (g->IsInMemoryDataTransferEnabled()) {
+		MakeDataBlock(g, args...);
+	}
+	else {
+		MakeFile(args...);
+	}
+}
+
+// 半角英数字以外を全てアンダースコアに置換する
+std::string SanitizeForDataBlock(const std::string& str)
+{
+	std::string res = str;
+	auto pos = res.begin();
+	while (pos = std::find_if(pos, res.end(), [](char c) { return !isalnum(c); }), pos != res.end())
+	{
+		res.replace(pos, pos + 1, 1, '_');
+		pos++;
+	}
+	return res;
 }
 
 template <class PointParam>
@@ -918,7 +1004,7 @@ protected:
 
 	GPMPlotBuffer2D Plot(GraphParam& i);
 
-	static std::string PlotCommand(const GraphParam& i);
+	static std::string PlotCommand(const GraphParam& i, const bool IsInMemoryDataTransferEnabled);
 	static std::string InitCommand();
 
 	std::vector<GraphParam> mParam;
@@ -989,7 +1075,7 @@ inline void GPMPlotBuffer2D<GraphParam>::Flush()
 	std::string c = "plot";
 	for (auto& i : mParam)
 	{
-		c += PlotCommand(i) + ", ";
+		c += PlotCommand(i, mCanvas->IsInMemoryDataTransferEnabled()) + ", ";
 	}
 	c.erase(c.end() - 2, c.end());
 	mCanvas->Command(c);
@@ -1000,8 +1086,13 @@ inline GPMPlotBuffer2D<GraphParam> GPMPlotBuffer2D<GraphParam>::Plot(GraphParam&
 {
 	if (i.mType == GraphParam::DATA)
 	{
-		i.mGraph = "$" + mCanvas->GetOutput() + "_"+ std::to_string(mParam.size()); // datablock name
-		std::replace(i.mGraph.begin(), i.mGraph.end(), '.', '_'); // sanitized
+		if (mCanvas->IsInMemoryDataTransferEnabled())
+		{
+			i.mGraph = "$" + SanitizeForDataBlock(mCanvas->GetOutput()) + "_" + std::to_string(mParam.size()); // datablock name
+		}
+		else {
+			i.mGraph = mCanvas->GetOutput() + ".tmp" + std::to_string(mParam.size()) + ".txt";
+		}
 		auto GET_ARRAY = [](plot::ArrayData& X, const std::string& x,
 							std::vector<DataIterator>& it, std::vector<std::string>& column, std::string& labelcolumn, size_t& size)
 		{
@@ -1074,7 +1165,7 @@ inline GPMPlotBuffer2D<GraphParam> GPMPlotBuffer2D<GraphParam>::Plot(GraphParam&
 			if (f.mY2) GET_ARRAY(f.mY2, "y2", it, column, labelcolumn, size);
 			if (f.mVariableColor) GET_ARRAY(f.mVariableColor, "variable_fillcolor", it, column, labelcolumn, size);
 		}
-		DefineDataBlock(it, size, i.mGraph, mCanvas);
+		MakeDataObject(mCanvas, it, size, i.mGraph);
 		if (!labelcolumn.empty()) column.emplace_back(std::move(labelcolumn));
 		i.mColumn = std::move(column);
 	}
@@ -1188,7 +1279,7 @@ PlotFilledCurves(const std::vector<Type1>& x, const std::vector<Type2>& y, const
 }
 
 template <class GraphParam>
-inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p)
+inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p, const bool IsInMemoryDataTransferEnabled)
 {
 	//filename or equation
 	std::string c;
@@ -1208,8 +1299,14 @@ inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p)
 		c.pop_back();
 		break;
 	case GraphParam::DATA:
-		//variable name
-		c += " " + p.mGraph;
+		if (IsInMemoryDataTransferEnabled) {
+			//variable name
+			c += " " + p.mGraph;
+		}
+		else {
+			//filename
+			c += " '" + p.mGraph + "'";
+		}
 
 		//using
 		c += " using ";
@@ -1517,7 +1614,7 @@ protected:
 
 	GPMPlotBufferCM Plot(GraphParam& i);
 
-	static std::string PlotCommand(const GraphParam& i);
+	static std::string PlotCommand(const GraphParam& i, const bool IsInMemoryDataTransferEnabled);
 	static std::string InitCommand();
 
 	std::vector<GraphParam> mParam;
@@ -1601,7 +1698,7 @@ inline void GPMPlotBufferCM<GraphParam>::Flush()
 	std::string c = "splot";
 	for (auto& i : mParam)
 	{
-		c += PlotCommand(i) + ", ";
+		c += PlotCommand(i, mCanvas->IsInMemoryDataTransferEnabled()) + ", ";
 	}
 	c.erase(c.end() - 2, c.end());
 	mCanvas->Command(c);
@@ -1653,8 +1750,13 @@ struct GetCoordFromRange
 template <class GraphParam>
 inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam& i)
 {
-	i.mGraph = "$" + mCanvas->GetOutput() + "_" + std::to_string(mParam.size()); // datablock name
-	std::replace(i.mGraph.begin(), i.mGraph.end(), '.', '_'); // sanitized
+	if (mCanvas->IsInMemoryDataTransferEnabled())
+	{
+		i.mGraph = "$" + SanitizeForDataBlock(mCanvas->GetOutput()) + "_" + std::to_string(mParam.size()); // datablock name
+	}
+	else {
+		i.mGraph = mCanvas->GetOutput() + ".tmp" + std::to_string(mParam.size()) + ".txt";
+	}
 	auto GET_ARRAY = [](plot::ArrayData& X, const std::string& x,
 						std::vector<DataIterator>& it, std::vector<std::string>& column, std::string& labelcolumn, size_t& size)
 	{
@@ -1711,12 +1813,12 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				{
 					const auto& y = m.mYCoord.GetVector();
 					if (y.size() != ysize) throw InvalidArg("size of y coordinate list and the y size of mat must be the same.");
-					DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromVector(y), i.mGraph, mCanvas);
+					MakeDataObject(mCanvas, m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromVector(y), i.mGraph);
 				}
 				else
 				{
 					auto y = m.mYRange;
-					DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromRange(y, ysize), i.mGraph, mCanvas);
+					MakeDataObject(mCanvas,m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromRange(y, ysize), i.mGraph);
 				}
 			}
 			else
@@ -1726,12 +1828,12 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				{
 					const auto& y = m.mYCoord.GetVector();
 					if (y.size() != ysize) throw InvalidArg("size of y coordinate list and the y size of mat must be the same.");
-					DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromVector(y), i.mGraph, mCanvas);
+					MakeDataObject(mCanvas, m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromVector(y), i.mGraph);
 				}
 				else
 				{
 					auto y = m.mYRange;
-					DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromRange(y, ysize), i.mGraph, mCanvas);
+					MakeDataObject(mCanvas, m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromRange(y, ysize), i.mGraph);
 				}
 			}
 		}
@@ -1790,10 +1892,19 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				std::tie(start, incr, end) = m.mCntrLevelsIncremental;
 				mCanvas->Command(Format("set cntrparam levels incremental %lf, %lf, %lf", start, incr, end));
 			}
+
 			mCanvas->Command("set pm3d implicit");
 			mCanvas->Command("set contour base");
 			mCanvas->Command("unset surface");
-			mCanvas->Command("set table " + i.mGraph + "_cntr");
+			if (mCanvas->IsInMemoryDataTransferEnabled()) {
+				mCanvas->Command("set table " + i.mGraph + "_cntr");
+			}
+			else {
+				std::string path = i.mGraph;
+				path.erase(path.end() - 3, path.end());
+				path += "cntr.txt";
+				mCanvas->Command("set table '" + path + "'");
+			}
 			//3:4:column[2]でplotする。
 			mCanvas->Command(Format("splot '%s' using 3:4:%s t '%s'", i.mGraph, column[2], i.mTitle));
 			mCanvas->Command("unset table");
@@ -1830,7 +1941,7 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 		{
 			GET_ARRAY(p.mVariableSize, "variable_size", it, column, labelcolumn, size);
 		}
-		DefineDataBlock(it, size, i.mGraph, mCanvas);
+		MakeDataObject(mCanvas, it, size, i.mGraph);
 	}
 	else if (i.IsVector())
 	{
@@ -1854,7 +1965,7 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 		{
 			GET_ARRAY(v.mVariableColor, "variable_color", it, column, labelcolumn, size);
 		}
-		DefineDataBlock(it, size, i.mGraph, mCanvas);
+		MakeDataObject(mCanvas, it, size, i.mGraph);
 	}
 	if (!labelcolumn.empty()) column.emplace_back(std::move(labelcolumn));
 	i.mColumn = std::move(column);
@@ -2037,7 +2148,7 @@ PlotColormap(const Matrix<double>& map, std::pair<double, double> x, std::pair<d
 }
 
 template <class GraphParam>
-inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p)
+inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p, const bool IsInMemoryDataTransferEnabled)
 {
 	//filename or equation
 	std::string c;
@@ -2057,8 +2168,14 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p)
 		c.pop_back();
 		break;
 	case GraphParam::DATA:
-		//variable name
-		c += " " + p.mGraph;
+		if (IsInMemoryDataTransferEnabled) {
+			//variable name
+			c += " " + p.mGraph;
+		}
+		else {
+			//filename
+			c += " '" + p.mGraph + "'";
+		}
 
 		//using
 		c += " using ";
@@ -2104,7 +2221,14 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p)
 		auto& m = p.GetColormapParam();
 		if (m.mWithContour)
 		{
-			c += ", " + p.mGraph + "_cntr with line";
+			if (IsInMemoryDataTransferEnabled) {
+				c += ", " + p.mGraph + "_cntr with line";
+			}
+			else {
+				std::string str = "'" + p.mGraph;
+				str.erase(str.end() - 3, str.end());
+				c += ", " + str + "cntr.txt' with line";
+			}
 			if (p.mTitle == "notitle") c += " notitle";
 			else c += " title '" + p.mTitle + "'";
 			if (m.mCntrLineType != -2) c += Format(" linetype %d", m.mCntrLineType);

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -495,14 +495,14 @@ inline void MakeDataBlock(GPMCanvas* g, const Matrix<double>& map, GetX getx, Ge
 }
 
 template <class ...Args>
-inline void MakeDataObject(GPMCanvas* g, Args ...args)
+inline void MakeDataObject(GPMCanvas* g, Args&& ...args)
 {
 	if (g->IsInMemoryDataTransferEnabled()) 
 	{
-		MakeDataBlock(g, args...);
+		MakeDataBlock(g, std::forward<Args>(args)...);
 	}
 	else {
-		MakeFile(args...);
+		MakeFile(std::forward<Args>(args)...);
 	}
 }
 

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -1284,7 +1284,8 @@ inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p,
 {
 	//filename or equation
 	std::string c;
-	switch (p.mType) {
+	switch (p.mType) 
+	{
 	case GraphParam::EQUATION:
 		//equation
 		c += " " + p.mGraph;

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -506,7 +506,7 @@ inline void MakeDataObject(GPMCanvas* g, Args ...args)
 }
 
 // 半角英数字以外を全てアンダースコアに置換する
-std::string SanitizeForDataBlock(const std::string& str)
+inline std::string SanitizeForDataBlock(const std::string& str)
 {
 	std::string res = str;
 	auto pos = res.begin();

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -1790,11 +1790,10 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				std::tie(start, incr, end) = m.mCntrLevelsIncremental;
 				mCanvas->Command(Format("set cntrparam levels incremental %lf, %lf, %lf", start, incr, end));
 			}
-			std::string variable_name_contour = i.mGraph + "_cntr";
 			mCanvas->Command("set pm3d implicit");
 			mCanvas->Command("set contour base");
 			mCanvas->Command("unset surface");
-			mCanvas->Command("set table " + variable_name_contour);
+			mCanvas->Command("set table " + i.mGraph + "_cntr");
 			//3:4:column[2]でplotする。
 			mCanvas->Command(Format("splot '%s' using 3:4:%s t '%s'", i.mGraph, column[2], i.mTitle));
 			mCanvas->Command("unset table");

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -378,7 +378,7 @@ namespace detail
 
 using DataIterator = Variant<std::vector<double>::const_iterator, std::vector<std::string>::const_iterator>;
 
-inline std::string MakeDataBlock(std::vector<DataIterator>& its, size_t size, const std::string& variable_name)
+inline std::string DefineDataBlock(std::vector<DataIterator>& its, size_t size, const std::string& variable_name)
 {
 	auto f = Overload([](std::vector<double>::const_iterator& it, std::ostringstream& oss) { oss << " " << *it; ++it; },
 		[](std::vector<std::string>::const_iterator& it, std::ostringstream& oss) { oss << " " << *it; ++it; });
@@ -397,7 +397,7 @@ inline std::string MakeDataBlock(std::vector<DataIterator>& its, size_t size, co
 }
 
 template <class GetX, class GetY>
-inline std::string MakeDataBlock(const Matrix<double>& map, GetX getx, GetY gety, const std::string& variable_name)
+inline std::string DefineDataBlock(const Matrix<double>& map, GetX getx, GetY gety, const std::string& variable_name)
 {
 	std::ostringstream oss;
 	oss << variable_name + " << EOD\n";
@@ -1074,7 +1074,7 @@ inline GPMPlotBuffer2D<GraphParam> GPMPlotBuffer2D<GraphParam>::Plot(GraphParam&
 			if (f.mY2) GET_ARRAY(f.mY2, "y2", it, column, labelcolumn, size);
 			if (f.mVariableColor) GET_ARRAY(f.mVariableColor, "variable_fillcolor", it, column, labelcolumn, size);
 		}
-		mCanvas->Command(MakeDataBlock(it, size, i.mGraph));
+		mCanvas->Command(DefineDataBlock(it, size, i.mGraph));
 		if (!labelcolumn.empty()) column.emplace_back(std::move(labelcolumn));
 		i.mColumn = std::move(column);
 	}
@@ -1711,12 +1711,12 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				{
 					const auto& y = m.mYCoord.GetVector();
 					if (y.size() != ysize) throw InvalidArg("size of y coordinate list and the y size of mat must be the same.");
-					mCanvas->Command(MakeDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromVector(y), i.mGraph));
+					mCanvas->Command(DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromVector(y), i.mGraph));
 				}
 				else
 				{
 					auto y = m.mYRange;
-					mCanvas->Command(MakeDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromRange(y, ysize), i.mGraph));
+					mCanvas->Command(DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromVector(x), GetCoordFromRange(y, ysize), i.mGraph));
 				}
 			}
 			else
@@ -1726,12 +1726,12 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 				{
 					const auto& y = m.mYCoord.GetVector();
 					if (y.size() != ysize) throw InvalidArg("size of y coordinate list and the y size of mat must be the same.");
-					mCanvas->Command(MakeDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromVector(y), i.mGraph));
+					mCanvas->Command(DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromVector(y), i.mGraph));
 				}
 				else
 				{
 					auto y = m.mYRange;
-					mCanvas->Command(MakeDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromRange(y, ysize), i.mGraph));
+					mCanvas->Command(DefineDataBlock(m.mZMap.GetMatrix(), GetCoordFromRange(x, xsize), GetCoordFromRange(y, ysize), i.mGraph));
 				}
 			}
 		}
@@ -1831,7 +1831,7 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 		{
 			GET_ARRAY(p.mVariableSize, "variable_size", it, column, labelcolumn, size);
 		}
-		mCanvas->Command(MakeDataBlock(it, size, i.mGraph));
+		mCanvas->Command(DefineDataBlock(it, size, i.mGraph));
 	}
 	else if (i.IsVector())
 	{
@@ -1855,7 +1855,7 @@ inline GPMPlotBufferCM<GraphParam> GPMPlotBufferCM<GraphParam>::Plot(GraphParam&
 		{
 			GET_ARRAY(v.mVariableColor, "variable_color", it, column, labelcolumn, size);
 		}
-		mCanvas->Command(MakeDataBlock(it, size, i.mGraph));
+		mCanvas->Command(DefineDataBlock(it, size, i.mGraph));
 	}
 	if (!labelcolumn.empty()) column.emplace_back(std::move(labelcolumn));
 	i.mColumn = std::move(column);

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -506,7 +506,7 @@ inline void MakeDataObject(GPMCanvas* g, Args ...args)
 	}
 }
 
-// 半角英数字以外を全てアンダースコアに置換する
+// Replace non-alphanumeric characters with '_'
 inline std::string SanitizeForDataBlock(const std::string& str)
 {
 	std::string res = str;

--- a/ADAPT/GPM2/GPMCanvas.h
+++ b/ADAPT/GPM2/GPMCanvas.h
@@ -1199,7 +1199,7 @@ inline std::string GPMPlotBuffer2D<GraphParam>::PlotCommand(const GraphParam& p)
 		break;
 	case GraphParam::FILE:
 		//filename
-		c += "'" + p.mGraph + "'";
+		c += " '" + p.mGraph + "'";
 
 		//using
 		c += " using ";
@@ -2049,7 +2049,7 @@ inline std::string GPMPlotBufferCM<GraphParam>::PlotCommand(const GraphParam& p)
 		break;
 	case GraphParam::FILE:
 		//filename
-		c += "'" + p.mGraph + "'";
+		c += " '" + p.mGraph + "'";
 
 		//using
 		c += " using ";

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ GPMCanvas::SetGnuplotPath("path to gnuplot");
 std::string norm = std::to_string(250. / std::sqrt(2 * 3.1415926535));
 std::string equation = norm + "*exp(-x*x/2)";
 
-std::random_device rd;
 std::mt19937_64 mt(0);
 std::normal_distribution<> nd(0., 1.);
 std::vector<double> x1(32, 0);

--- a/examples/example_2d.h
+++ b/examples/example_2d.h
@@ -6,7 +6,7 @@
 
 using namespace adapt::gpm2;
 
-int example_2d()
+int example_2d(const std::string output_filename = "example_2d.png", const bool IsInMemoryDataTransferEnabled = false)
 {
 	std::string norm = std::to_string(250. / std::sqrt(2 * 3.1415926535));
 	std::string equation = norm + "*exp(-x*x/2)";
@@ -45,8 +45,9 @@ int example_2d()
 	yerrorbar      ... yerrorbar
 	*/
 
-	GPMCanvas2D g("example_2d.png");
+	GPMCanvas2D g(output_filename);
 	g.ShowCommands(true);
+	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
 	g.SetTitle("example\\_2d");
 	g.SetXRange(-4.0, 4.0);
 	g.SetXLabel("x");

--- a/examples/example_2d.h
+++ b/examples/example_2d.h
@@ -6,7 +6,7 @@
 
 using namespace adapt::gpm2;
 
-int example_2d(const std::string output_filename = "example_2d.png", const bool IsInMemoryDataTransferEnabled = false)
+int example_2d(const std::string output_filename = "example_2d.png", const bool enable_in_memory_data_transfer = false)
 {
 	std::string norm = std::to_string(250. / std::sqrt(2 * 3.1415926535));
 	std::string equation = norm + "*exp(-x*x/2)";
@@ -47,7 +47,7 @@ int example_2d(const std::string output_filename = "example_2d.png", const bool 
 
 	GPMCanvas2D g(output_filename);
 	g.ShowCommands(true);
-	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+	g.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
 	g.SetTitle("example\\_2d");
 	g.SetXRange(-4.0, 4.0);
 	g.SetXLabel("x");

--- a/examples/example_2d.h
+++ b/examples/example_2d.h
@@ -11,7 +11,6 @@ int example_2d(const std::string output_filename = "example_2d.png", const bool 
 	std::string norm = std::to_string(250. / std::sqrt(2 * 3.1415926535));
 	std::string equation = norm + "*exp(-x*x/2)";
 
-	std::random_device rd;
 	std::mt19937_64 mt(0);
 	std::normal_distribution<> nd(0., 1.);
 	std::vector<double> x1(32, 0);

--- a/examples/example_colormap.h
+++ b/examples/example_colormap.h
@@ -32,7 +32,7 @@ double fieldy(double x, double y)
 	double f2 = 3 * y / std::pow(r(x + 3, y), 3);
 	return f1 - f2;
 }
-int example_colormap()
+int example_colormap(const std::string output_filename="example_colormap.png", const bool IsInMemoryDataTransferEnabled=false)
 {
 	adapt::Matrix<double> m(100, 100);
 	std::pair<double, double> xrange = { -9.9, 9.9 };
@@ -87,10 +87,11 @@ int example_colormap()
 	*/
 
 
-	GPMMultiPlot multi("example_colormap.png", 1, 2, 1200, 600);
+	GPMMultiPlot multi(output_filename, 1, 2, 1200, 600);
 
 	GPMCanvasCM g1("example_colormap_tmpfile");
 	g1.ShowCommands(true);
+	g1.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
 	g1.SetTitle("example\\_colormap");
 	g1.SetPaletteDefined({ {0, "yellow" }, { 4.5, "red" }, { 5., "black" }, { 5.5, "blue"}, { 10, "cyan" } });
 	g1.SetSizeRatio(-1);
@@ -107,6 +108,7 @@ int example_colormap()
 
 	GPMCanvasCM g2("example_colormap_tmpfile");
 	g2.ShowCommands(true);
+	g2.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
 	g2.SetTitle("example\\_contour");
 	g2.SetPaletteDefined({ {0, "yellow" }, { 4.5, "red" }, { 5., "black" }, { 5.5, "blue"}, { 10, "cyan" } });
 	g2.SetSizeRatio(-1);

--- a/examples/example_colormap.h
+++ b/examples/example_colormap.h
@@ -32,7 +32,7 @@ double fieldy(double x, double y)
 	double f2 = 3 * y / std::pow(r(x + 3, y), 3);
 	return f1 - f2;
 }
-int example_colormap(const std::string output_filename="example_colormap.png", const bool IsInMemoryDataTransferEnabled=false)
+int example_colormap(const std::string output_filename="example_colormap.png", const bool enable_in_memory_data_transfer=false)
 {
 	adapt::Matrix<double> m(100, 100);
 	std::pair<double, double> xrange = { -9.9, 9.9 };
@@ -91,7 +91,7 @@ int example_colormap(const std::string output_filename="example_colormap.png", c
 
 	GPMCanvasCM g1("example_colormap_tmpfile");
 	g1.ShowCommands(true);
-	g1.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+	g1.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
 	g1.SetTitle("example\\_colormap");
 	g1.SetPaletteDefined({ {0, "yellow" }, { 4.5, "red" }, { 5., "black" }, { 5.5, "blue"}, { 10, "cyan" } });
 	g1.SetSizeRatio(-1);
@@ -108,7 +108,7 @@ int example_colormap(const std::string output_filename="example_colormap.png", c
 
 	GPMCanvasCM g2("example_colormap_tmpfile");
 	g2.ShowCommands(true);
-	g2.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+	g2.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
 	g2.SetTitle("example\\_contour");
 	g2.SetPaletteDefined({ {0, "yellow" }, { 4.5, "red" }, { 5., "black" }, { 5.5, "blue"}, { 10, "cyan" } });
 	g2.SetSizeRatio(-1);

--- a/examples/example_filledcurve.h
+++ b/examples/example_filledcurve.h
@@ -15,7 +15,7 @@ struct ChiSquare
 	double k;
 };
 
-int example_filledcurve(const std::string output_filename = "example_filledcurve.png", const bool IsInMemoryDataTransferEnabled = false)
+int example_filledcurve(const std::string output_filename = "example_filledcurve.png", const bool enable_in_memory_data_transfer = false)
 {
 	std::vector<double> x(401, 0);
 	std::vector<double> y1(401, 0);
@@ -56,7 +56,7 @@ int example_filledcurve(const std::string output_filename = "example_filledcurve
 
 	GPMCanvas2D g(output_filename);
 	g.ShowCommands(true);
-	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+	g.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
 	g.SetTitle("example\\_filledcurve");
 	g.SetXRange(0, 8.0);
 	g.SetYRange(0, 1.0);

--- a/examples/example_filledcurve.h
+++ b/examples/example_filledcurve.h
@@ -15,7 +15,7 @@ struct ChiSquare
 	double k;
 };
 
-int example_filledcurve()
+int example_filledcurve(const std::string output_filename = "example_filledcurve.png", const bool IsInMemoryDataTransferEnabled = false)
 {
 	std::vector<double> x(401, 0);
 	std::vector<double> y1(401, 0);
@@ -54,8 +54,9 @@ int example_filledcurve()
 	below          ... the filled area is limited to the below side of baseline or y2 curve.
 	*/
 
-	GPMCanvas2D g("example_filledcurve.png");
+	GPMCanvas2D g(output_filename);
 	g.ShowCommands(true);
+	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
 	g.SetTitle("example\\_filledcurve");
 	g.SetXRange(0, 8.0);
 	g.SetYRange(0, 1.0);

--- a/examples/example_for_loop.h
+++ b/examples/example_for_loop.h
@@ -1,11 +1,15 @@
+#ifndef EXAMPLE_FORLOOP_H
+#define EXAMPLE_FORLOOP_H
+
 #include <ADAPT/GPM2/GPMCanvas.h>
-#include <string>
 
 using namespace adapt::gpm2;
 
-int example_for_loop()
+int example_for_loop(const std::string output_filename = "example_for_loop.png", const bool IsInMemoryDataTransferEnabled = false)
 {
-	GPMCanvas2D g("example_for_loop.png");
+	GPMCanvas2D g(output_filename);
+	g.ShowCommands(true);
+	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
 
 	auto buf = g.GetBuffer();
 	for (int i = 0; i < 5; ++i)
@@ -16,3 +20,5 @@ int example_for_loop()
 	buf.Flush();
 	return 0;
 }
+
+#endif

--- a/examples/example_for_loop.h
+++ b/examples/example_for_loop.h
@@ -5,11 +5,11 @@
 
 using namespace adapt::gpm2;
 
-int example_for_loop(const std::string output_filename = "example_for_loop.png", const bool IsInMemoryDataTransferEnabled = false)
+int example_for_loop(const std::string output_filename = "example_for_loop.png", const bool enable_in_memory_data_transfer = false)
 {
 	GPMCanvas2D g(output_filename);
 	g.ShowCommands(true);
-	g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+	g.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
 
 	auto buf = g.GetBuffer();
 	for (int i = 0; i < 5; ++i)

--- a/examples/example_string.h
+++ b/examples/example_string.h
@@ -5,7 +5,7 @@
 
 using namespace adapt::gpm2;
 
-int example_string()
+int example_string(const std::string output_filename = "example_string_label.png", const bool IsInMemoryDataTransferEnabled = false)
 {
     std::vector<std::string> x;
     std::vector<double> y;
@@ -21,8 +21,9 @@ int example_string()
     x.push_back("label-nine");  y.push_back(9);
     x.push_back("label-ten");  y.push_back(10);
 
-    GPMCanvas2D g("string_label.png");
+    GPMCanvas2D g(output_filename);
     g.ShowCommands(true);
+    g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
     g.SetXRange(-1, 10);
     g.SetYRange(0, 11);
     g.SetXticsRotate(-45);

--- a/examples/example_string.h
+++ b/examples/example_string.h
@@ -5,7 +5,7 @@
 
 using namespace adapt::gpm2;
 
-int example_string(const std::string output_filename = "example_string_label.png", const bool IsInMemoryDataTransferEnabled = false)
+int example_string(const std::string output_filename = "example_string_label.png", const bool enable_in_memory_data_transfer = false)
 {
     std::vector<std::string> x;
     std::vector<double> y;
@@ -23,7 +23,7 @@ int example_string(const std::string output_filename = "example_string_label.png
 
     GPMCanvas2D g(output_filename);
     g.ShowCommands(true);
-    g.EnableInMemoryDataTransfer(IsInMemoryDataTransferEnabled); // Enable or disable datablock feature of gnuplot
+    g.EnableInMemoryDataTransfer(enable_in_memory_data_transfer); // Enable or disable datablock feature of gnuplot
     g.SetXRange(-1, 10);
     g.SetYRange(0, 11);
     g.SetXticsRotate(-45);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -20,4 +20,9 @@ int main()
 	example_string();
 
 	example_for_loop();
+
+	//The following are tests for in-memory data transfer (datablock feature).
+	example_2d("example_2d-inmemory.png", true);
+
+	example_colormap("example_colormap@inmemory.png", true);
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -22,6 +22,7 @@ int main()
 	example_for_loop();
 
 	//The following are tests for in-memory data transfer (datablock feature).
+	//Non-alphanumeric characters are replaced with '_'.
 	example_2d("example_2d-inmemory.png", true);
 
 	example_colormap("example_colormap@inmemory.png", true);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -22,7 +22,7 @@ int main()
 	example_for_loop();
 
 	//The following are tests for in-memory data transfer (datablock feature).
-	//Non-alphanumeric characters are replaced with '_'.
+	//Non-alphanumeric characters are intentionally used to test SanitizeForDataBlock().
 	example_2d("example_2d-inmemory.png", true);
 
 	example_colormap("example_colormap@inmemory.png", true);


### PR DESCRIPTION
Closes #10 

一時ファイルを介してではなく、datablockを定義してgnuplotに直接データを渡すようにしました。
メモリ使用量を抑えるため、`DefineDataBlock()`内で、gnuplotへコマンドを逐次送信する実装にしてあります。

 一時ファイル作成機能を削除した影響でgnuplotの要求バージョンが5.2以上になっていますが、gnuplot5.2は[約三年前にリリース](http://www.gnuplot.info/)されているため、ほとんどの環境では問題ないと考えています。
オプションで選択可能にしたほうがよければ、その旨をコメントしてください。